### PR TITLE
Allow multi-column .from/.to keys in new_xmap_tbl()

### DIFF
--- a/R/xmap_tbl.R
+++ b/R/xmap_tbl.R
@@ -10,8 +10,8 @@ new_xmap_tbl <- function(x = list(
     if (!length(x) == 3) {
         abort("`x` must be a list of length 3.")
     }
-    if (any(lapply(x, ncol) != 1)) {
-        abort("`.from`, `.to`, `.weight_by` should only have one column each")
+    if (ncol(x$.weight_by) != 1) {
+        abort(".weight_by should only have one column")
     }
     if (!is.numeric(x$.weight_by[[1]])) {
         abort("`x$`.weight_by`[[1]]` must be a numeric vector.")
@@ -278,8 +278,10 @@ tbl_sum.xmap_tbl <- function(x, ...) {
     n_to_set <- vec_unique_count(x$.to)
     extra_info <- c("with unique keys" = sprintf(
         "[%s] %s -> [%s] %s",
-        n_from_set, names(x$.from),
-        n_to_set, names(x$.to)
+        n_from_set,
+        paste(names(x$.from), collapse = "-"),
+        n_to_set,
+        paste(names(x$.to), collapse = "-")
     ))
     c(default_header, extra_info)
 }

--- a/tests/testthat/helper-data.R
+++ b/tests/testthat/helper-data.R
@@ -6,3 +6,16 @@ simple_xmap <- as_xmap_tbl(
     simple_links,
     xcode, alphacode, weight
 )
+
+multicol_links <- simple_links |>
+    tidyr::separate_wider_position(
+        xcode,
+        c(x_letter = 1, x_numbers = 4)
+    )
+multicol_xmap <- xmap:::new_xmap_tbl(
+    list(
+        .from = multicol_links[c("x_letter", "x_numbers")],
+        .to = multicol_links["alphacode"],
+        .weight_by = multicol_links["weight"]
+    )
+)

--- a/tests/testthat/test-xmap_tbl.R
+++ b/tests/testthat/test-xmap_tbl.R
@@ -13,6 +13,24 @@ test_that("new_xmap_tbl() works", {
     )
 })
 
+test_that("new_xmap_tbl() handles multicol cases correctly", {
+    expect_error(
+        new_xmap_tbl(list(
+            .from = simple_links["xcode"],
+            .to = simple_links["alphacode"],
+            .weight_by = simple_links[c("weight", "xcode")]
+        ))
+    )
+    expect_s3_class(
+        new_xmap_tbl(list(
+            .from = simple_links[c("alphacode", "xcode")],
+            .to = simple_links["alphacode"],
+            .weight_by = simple_links["weight"]
+        )),
+        "xmap_tbl"
+    )
+})
+
 test_that("xmap_tbl() works", {
     expect_s3_class(
         xmap_tbl(


### PR DESCRIPTION
## Summary

- Removes the single-column restriction on `.from`/`.to` in `new_xmap_tbl()` — a crossmap key is now allowed to be composite, e.g. `.from = tibble(year, region)` instead of just `.from = tibble(region)`. `.weight_by` is still required to be a single column.
- Updates `tbl_sum.xmap_tbl()`'s header so it prints correctly when `.from`/`.to` have more than one column.
- Adds test objects/coverage for the multi-column case.

## Why

Because `.from`/`.to` can hold more than one column, and matrix rows/columns need a single atomic label.

`multicol-support` (`ea248d4`, "allow multiple columns for `.from`, `.to` in `new_xmap_tbl()`") removed the single-column restriction on `.from`/`.to` — a crossmap key is allowed to be composite, e.g. `.from = tibble(year, region)` instead of just `.from = tibble(region)`. That commit's own fix for the print method shows the same problem in miniature: `names(x$.from)` (a vector of column names) had to become `paste(names(x$.from), collapse = "-")` (a single string) just to print a header.

`ggxmap_as_matrix()` (from the `autoplot` branch, built on top of this one) hits the same wall one level down, on values rather than names: `matrix_long <- .xmap_tbl |> tidyr::complete(.from, .to) |> ...` needs `.from` and `.to` to each be one discrete axis for the tile plot (`aes(y = .from, x = .to)`), and matrix rows/columns fundamentally have one name per row/column, not a tuple. If `.from` carries `(year, region)` as two columns, there's no single value to hand to `tidyr::complete()` or to a ggplot discrete axis — you'd be asking `tidyr::complete()` to cross-join on a 2-column key pair and ggplot to plot a tuple as a single categorical position, neither of which works directly.

`xmap_collapse_multicol()` is the shim that papers over this: it pastes every sub-column of `.from` into one string (default `*`-separated) and does the same for `.to`, so a composite key like `(2020, "AUS")` becomes the single string `"2020*AUS"` — something `tidyr::complete()` can cross and something ggplot/`dimnames()` can use as one row or column label. It has to run unconditionally (even for the common single-column case) because `ggxmap_as_matrix()` has no way of knowing ahead of time whether the `xmap_tbl` it was handed is single- or multi-column — collapsing is a no-op for single columns and load-bearing for composite ones, so it's applied uniformly rather than conditionally.

The same shim is needed by the bigraph mode (`ggxmap_as_bigraph()`) for an identical reason — `tidygraph::as_tbl_graph()` also needs one atomic node label per row, not a tuple — which is why `xmap_collapse_multicol()` lives once in `autoplot.R` and both plotting paths call it.

## Why merge this separately from `autoplot`

`multicol-support` is the prerequisite `autoplot` was built on top of, but is independently useful and independently mergeable — it only touches `new_xmap_tbl()`'s validation and the print header, with no dependency on plotting. Merging it now decouples the crossmap-key model change from `autoplot`'s readiness, so multi-column key support can ship in the next release even if `autoplot` isn't ready in time.

## Test plan

- [x] `new_xmap_tbl()` accepts multi-column `.from`/`.to` and still rejects multi-column `.weight_by`
- [x] `tbl_sum.xmap_tbl()` prints a sane header for multi-column keys
- [ ] `devtools::check()` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)