### PR TITLE
Add vignette-writing skill

### DIFF
--- a/.claude/skills/vignette-writing/SKILL.md
+++ b/.claude/skills/vignette-writing/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: vignette-writing
+description: Guidance to follow when writing or reviewing xmap vignettes (files in vignettes/*.Rmd). Use whenever drafting a new vignette, restructuring an existing one, or reviewing vignette content/structure.
+---
+
+# Writing xmap vignettes
+
+Before writing or substantially revising a vignette in `vignettes/`, consult:
+
+https://blog.r-hub.io/2020/06/03/vignettes/
+
+This covers practical guidance on vignette structure, tone, and build considerations (e.g. keeping vignettes runnable in reasonable time, precomputing/caching long-running examples, when to pre-build vs. let them run on `R CMD check`) that should inform how xmap's vignettes (e.g. `extracting-crossmaps-from-scripts.Rmd`, `handling-xmap-tbls.Rmd`, `xmap.Rmd`) are written.


### PR DESCRIPTION
## Summary
- Adds a `.claude/skills/vignette-writing` skill so future vignette work in `vignettes/` consults r-hub's vignette-writing guidance (https://blog.r-hub.io/2020/06/03/vignettes/).

## Test plan
- N/A (doc/skill file only, no code change)