### PR TITLE
Error on unmapped country codes in indstat country-lookup join

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # xmap (development version)
 
+* `data-raw/indstat.R`'s `country` -> `country_iso3c`/`country_name` join now errors on any `masked_sample$country` (UN M49 code) missing from `country_lookup`, instead of silently shipping `NA` ISO alpha-3 labels; a regression test in `test-indstat.R` guards the shipped `indstat` object against the same failure mode
+
 * Add overview of diagnostic validation functions to README & Getting Started Vignette
 * Add `validate_as_xmap()`, a generic with `data.frame` and `matrix` methods, for cheaply checking whether links (or a matrix) form a valid crossmap without building a detail object
 * `diagnose_as_xmap_tbl()` now always returns a single `xmap_diagnosis` object (`$valid`/`$details`), replacing the previous inconsistent `TRUE`/`FALSE`/`invisible(x)`/bare `list()` return contract; printing the result shows a readable pass/fail report

--- a/data-raw/indstat.R
+++ b/data-raw/indstat.R
@@ -11,7 +11,11 @@ indstat_country_lookup <-
 
 indstat_masked_sample <-
   readr::read_csv("data-raw/indstat_rev3_masked_subset.csv") |>
-  dplyr::left_join(indstat_country_lookup[c("code", "iso3c", "name")], by = dplyr::join_by(country == code)) |>
+  dplyr::inner_join(
+    indstat_country_lookup[c("code", "iso3c", "name")],
+    by = dplyr::join_by(country == code),
+    unmatched = c("error", "drop")
+  ) |>
   dplyr::rename(country_name = name, country_iso3c = iso3c)
 
 indstat <- list(

--- a/tests/testthat/test-indstat.R
+++ b/tests/testthat/test-indstat.R
@@ -1,0 +1,8 @@
+test_that("indstat$masked_sample has no unmapped country -> iso3c/name joins", {
+    expect_false(anyNA(indstat$masked_sample$country_iso3c))
+    expect_false(anyNA(indstat$masked_sample$country_name))
+})
+
+test_that("every masked_sample$country appears in country_lookup$code", {
+    expect_true(all(indstat$masked_sample$country %in% indstat$country_lookup$code))
+})


### PR DESCRIPTION
## Summary
- `data-raw/indstat.R`'s `country` -> `country_iso3c`/`country_name` join now uses `inner_join(unmatched = c("error", "drop"))` instead of a bare `left_join()`, so an M49 `country` code missing from `country_lookup` fails loudly at build time instead of silently shipping `NA` ISO alpha-3 labels
- Added a regression test (`test-indstat.R`) asserting the shipped `indstat` object has no unmapped `country` codes

Fixes #35

## Test plan
- [x] `devtools::load_all(); source("data-raw/indstat.R")` rebuilds `data/indstat.rda` cleanly, byte-identical to the current shipped version (no unmapped codes in the current 8-country subset)
- [x] Manually verified `inner_join(unmatched = c("error", "drop"))` actually errors on an unmatched `x` row (confirmed `left_join(unmatched = "error")` does *not*, since for `left_join` that argument only checks the `y` side)
- [x] `devtools::test()` — 120/120 passing, including the new `test-indstat.R`

🤖 Generated with [Claude Code](https://claude.com/claude-code)